### PR TITLE
Updated antena dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,31 @@
 {
   "name": "melf",
-  "version": "2.2.12",
+  "version": "2.2.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "antena": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/antena/-/antena-4.0.9.tgz",
-      "integrity": "sha512-EJYqDbh6pIbXthRyPMlZj+WXNSs5KjG485Wo6fw3jY9uxjjujTr/1EJrM666mHgQadXqGTBWel5TrnH7vsRRpw==",
+      "version": "4.0.10",
+      "resolved": "http://localhost:4873/antena/-/antena-4.0.10.tgz",
+      "integrity": "sha512-VYb1TP1050xjB8lg00EdeV54If4Lnds6Pq7YjgRgb3qGU/PjAMBpmDPz+gKxuxGNs356l10RSZfVnQtfgXxItQ==",
       "requires": {
-        "posix-socket": "0.0.10",
+        "posix-socket": "0.0.11",
         "ws": "^6.2.0"
       }
     },
     "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "version": "1.0.1",
+      "resolved": "http://localhost:4873/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "posix-socket": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/posix-socket/-/posix-socket-0.0.10.tgz",
-      "integrity": "sha512-NNUsRuk7ZTA+6JzuGVusX0REOJVsZyxUZQam9so2k++TIHz9PC9n5x6hqX1gjR6xSz/SEVRtACWOJApOApZgOw=="
+      "version": "0.0.11",
+      "resolved": "http://localhost:4873/posix-socket/-/posix-socket-0.0.11.tgz",
+      "integrity": "sha512-MZjARSypNCuVg5GM6FUeJQLxcWO/WWEQJb4NFxLXczHUpFUrx3oasn0DTHUbteDKZqGM7qlWk9FSciKmaOEkww=="
     },
     "ws": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "resolved": "http://localhost:4873/ws/-/ws-6.2.1.tgz",
       "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
       "requires": {
         "async-limiter": "~1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "melf",
   "description": "(A)Synchronous remote procedure calls",
-  "version": "2.2.13",
+  "version": "2.2.14",
   "author": {
     "name": "Laurent Christophe",
     "email": "lachrist@vub.ac.be"
@@ -10,7 +10,7 @@
   "homepage": "http://github.com/lachrist/melf",
   "license": "MIT",
   "dependencies": {
-    "antena": "4.0.9"
+    "antena": "4.0.10"
   },
   "main": "lib/main.js",
   "keywords": [


### PR DESCRIPTION
This is required for supporting current Node.js versions (due to melf->posix-socket dependency)